### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,43 +21,43 @@ commands and setup for the simulator as shown below
 
 `Setup`
 
-git clone https://github.com/zombieCraig/ICSim
-sudo apt-get install libsdl2-dev libsdl2-image-dev –y
-sudo apt-get install can-utils -y
-Cd ICSim
-Make
-./setup_vcan.sh
+- git clone https://github.com/zombieCraig/ICSim
+- sudo apt-get install libsdl2-dev libsdl2-image-dev –y
+- sudo apt-get install can-utils -y
+- cd ICSim
+- make
+- ./setup_vcan.sh
 
 
 `Check if working`
 
-Ifconfig vcan0
+- Ifconfig vcan0
 
 `Run Simulation`
 
-./icsim vcan0 = speedometer
-./controls vcan0 = controls
+- ./icsim vcan0 = speedometer
+- ./controls vcan0 = controls
 
 `Controls`
 
-Accerlate = Up Arrow
-Left/Right Turn signal = left/right arrows
-Unlock Front left/right doors = right-shift +A, right-shift +B
-Unlock Back left/Right = right-shift+X, right-shift+Y
-Lock All Doors = Hold right shift key, Tap left shift
-Unlock all doors = Hold left shift key, Tap right shift 
+- Accerlate = Up Arrow
+- Left/Right Turn signal = left/right arrows
+- Unlock Front left/right doors = right-shift +A, right-shift +B
+- Unlock Back left/Right = right-shift+X, right-shift+Y
+- Lock All Doors = Hold right shift key, Tap left shift
+- Unlock all doors = Hold left shift key, Tap right shift 
 
 
 `Commands`
 
-cangen vcan0 = send CAN packet
-candump vcan0 = dump live can files on vcan0
-candump -I vcan0 = dumps the can packets live into a file until ctrl_C pressed
-cansniffer -c vcan0 = live feed of can packets with highlighted changes 
--press -0000 +enter, +ID to view specific ID CAN information
-canplayer -I canfile.log = replay CAN packets via file
-wc -l canfile.log = vuew amount of CAN commands sent
-split -l "1/2 CAN total" canfile.log name = splits the file into half and replays that
+- cangen vcan0 = send CAN packet
+- candump vcan0 = dump live can files on vcan0
+- candump -I vcan0 = dumps the can packets live into a file until ctrl_C pressed
+- cansniffer -c vcan0 = live feed of can packets with highlighted changes 
+- press -0000 +enter, +ID to view specific ID CAN information
+- canplayer -I canfile.log = replay CAN packets via file
+- wc -l canfile.log = vuew amount of CAN commands sent
+- split -l "1/2 CAN total" canfile.log name = splits the file into half and replays that
 
 
 `Extra Material`


### PR DESCRIPTION
- In Markdown a single newline is not interpreted, so your lists were actually paragraphs. I changed them into an unordered list
- Uncapitalised some syntactically incorrect bash commands